### PR TITLE
Collision handler y collision layers

### DIFF
--- a/src/SourceFiles/Collider.cpp
+++ b/src/SourceFiles/Collider.cpp
@@ -1,18 +1,18 @@
 #include "Collider.h"
 
 Collider::Collider(b2World* world, b2BodyType type, float x, float y, float width, float height,
-	float density, float friction, float restitution, int groupIndex, bool sensor) :
+	float density, float friction, float restitution, CollisionLayer c, bool sensor) :
 	world_(world),
 	Component(ComponentType::Collider)
 {   
 	bodyDef_.type = type;
 	bodyDef_.position.Set(x, y);
 	body_ = world_->CreateBody(&bodyDef_);
-	createFixture(width, height, density, friction, restitution, groupIndex, sensor);
+	createFixture(width, height, density, friction, restitution, c, sensor);
 }
 
 void Collider::createFixture(float width, float height, float density,
-	float friction, float restitution, int groupIndex, bool sensor) {
+	float friction, float restitution, CollisionLayer c, bool sensor) {
 	widths_.push_back(width);
 	heights_.push_back(height);
 	b2PolygonShape shape;
@@ -23,7 +23,20 @@ void Collider::createFixture(float width, float height, float density,
 	aux.density = density;
 	aux.friction = friction;
 	aux.restitution = fmod(restitution, 1.0);
-	aux.filter.groupIndex = groupIndex;
+	switch (c) {
+	case 1:
+		aux.filter.categoryBits = Normal; //what am I?
+		aux.filter.maskBits = Normal | Player; //what do I collide with?
+		break;
+	case 2:
+		aux.filter.categoryBits = Player;
+		aux.filter.maskBits = Normal | Player | Triggers;
+		break;
+	case 3:
+		aux.filter.categoryBits = Triggers;
+		aux.filter.maskBits = Player;
+		break;
+	}
 	aux.isSensor = sensor;
 	fixtureDefs_.push_back(aux);
 	fixtures_.push_back(body_->CreateFixture(&fixtureDefs_.back()));

--- a/src/SourceFiles/Collider.cpp
+++ b/src/SourceFiles/Collider.cpp
@@ -24,16 +24,16 @@ void Collider::createFixture(float width, float height, float density,
 	aux.friction = friction;
 	aux.restitution = fmod(restitution, 1.0);
 	switch (c) {
-	case 1:
+	case Normal:
 		aux.filter.categoryBits = Normal; //what am I?
 		aux.filter.maskBits = Normal | Player; //what do I collide with?
 		break;
-	case 2:
+	case Player:
 		aux.filter.categoryBits = Player;
-		aux.filter.maskBits = Normal | Player | Triggers;
+		aux.filter.maskBits = Normal | Player | Trigger;
 		break;
-	case 3:
-		aux.filter.categoryBits = Triggers;
+	case Trigger:
+		aux.filter.categoryBits = Trigger;
 		aux.filter.maskBits = Player;
 		break;
 	}

--- a/src/SourceFiles/Collider.h
+++ b/src/SourceFiles/Collider.h
@@ -6,8 +6,14 @@
 class Collider : public Component
 {
 public:
+	//Add the different collision layers as we see fit
+	enum CollisionLayer{
+		Normal = 0x0001, //a collision layer can't be zero or else it won't collide
+		Player,
+		Triggers,
+	};
 	Collider(b2World* world, b2BodyType type, float x, float y, float width, float height,
-		float density, float friction, float restitution, int groupIndex, bool sensor);
+		float density, float friction, float restitution, CollisionLayer c, bool sensor);
 	~Collider() {
 		world_->DestroyBody(body_); world_ = nullptr;
 	}
@@ -37,12 +43,13 @@ public:
 	void setAwake(bool b) { body_->SetAwake(b); }
 	void setEnabled(bool b) { body_->SetEnabled(b); }
 	void setBullet(bool b) { body_->SetBullet(b); }
+	void setUserData(void* data) { body_->SetUserData(data); }
 	void setTransform(b2Vec2 pos, float angle) { body_->SetTransform(pos, angle); }
 	void setLinearVelocity(b2Vec2 vel) { body_->SetLinearVelocity(vel); }
-	void applyLinearImpulse(b2Vec2 force, b2Vec2 point) { body_->ApplyLinearImpulse(force, point, true); }
-	void applyForce(b2Vec2 force, b2Vec2 point) { body_->ApplyForce(force, point, true); }
+	void applyLinearImpulse(b2Vec2 force, b2Vec2 point) { body_->ApplyLinearImpulse(force, body_->GetPosition() + point, true); }
+	void applyForce(b2Vec2 force, b2Vec2 point) { body_->ApplyForce(force, body_->GetPosition() + point, true); }
 	void createFixture(float width, float height, float density,
-		float friction, float restitution, int groupIndex, bool sensor);
+		float friction, float restitution, CollisionLayer, bool sensor);
 	void destroyFixture(int i);
 
 private:

--- a/src/SourceFiles/Collider.h
+++ b/src/SourceFiles/Collider.h
@@ -5,12 +5,25 @@
 
 class Collider : public Component
 {
+private:
+	//general
+	b2Body* body_;
+	b2World* world_;
+	b2BodyDef bodyDef_;
+
+	//fixtures
+	vector<float> widths_;
+	vector<float> heights_;
+	vector<b2PolygonShape> shapes_;
+	vector<b2FixtureDef> fixtureDefs_;
+	vector<b2Fixture*> fixtures_;
+
 public:
 	//Add the different collision layers as we see fit
 	enum CollisionLayer{
 		Normal = 0x0001, //a collision layer can't be zero or else it won't collide
 		Player,
-		Triggers,
+		Trigger
 	};
 	Collider(b2World* world, b2BodyType type, float x, float y, float width, float height,
 		float density, float friction, float restitution, CollisionLayer c, bool sensor);
@@ -51,18 +64,5 @@ public:
 	void createFixture(float width, float height, float density,
 		float friction, float restitution, CollisionLayer, bool sensor);
 	void destroyFixture(int i);
-
-private:
-	//general
-	b2Body* body_;
-	b2World* world_;
-	b2BodyDef bodyDef_;
-
-	//fixtures
-	vector<float> widths_;
-	vector<float> heights_;
-	vector<b2PolygonShape> shapes_;
-	vector<b2FixtureDef> fixtureDefs_;
-	vector<b2Fixture*> fixtures_;
 };
 

--- a/src/SourceFiles/CollisionHandler.cpp
+++ b/src/SourceFiles/CollisionHandler.cpp
@@ -1,30 +1,47 @@
 #include "CollisionHandler.h"
 
+//Handles start of collisions
 void CollisionHandler::BeginContact(b2Contact* contact)
 { 
 	b2Fixture* fixA = contact->GetFixtureA();
 	b2Fixture* fixB = contact->GetFixtureB();
 
-	std::cout << "jajasi\n";
+	//player damage collision
+	Health* player = nullptr;
 
-	TriggerCollision(fixA, fixB);
+	//check collision then do whatever, in this case twice because it might be two players colliding 
+	if (ObjectCollidesWithPlayer(fixA, player)) {
+		player->subtractLife(1);
+		std::cout << "Health: " << player->getHealth() << endl;
+	}
+	if (ObjectCollidesWithPlayer(fixB, player)) {
+		player->subtractLife(1);
+		std::cout << "Health: " << player->getHealth() << endl;
+	}
 }
 
+//Handles end of collisions
 void CollisionHandler::EndContact(b2Contact* contact)
-{ /* handle end event */
+{ 
 }
 
+//If you want to disable a collision after it's detected
 void CollisionHandler::PreSolve(b2Contact* contact, const b2Manifold* oldManifold)
-{ /* handle pre-solve event */
+{
 }
 
+//Gather info about impulses
 void CollisionHandler::PostSolve(b2Contact* contact, const b2ContactImpulse* impulse)
-{ /* handle post-solve event */
+{
 }
 
-bool CollisionHandler::TriggerCollision(b2Fixture* fixA, b2Fixture* fixB) {
-	bool a = (fixA->IsSensor() || fixB->IsSensor());
-	if(a) std::cout << "trigger\n";
-	return a;
-	
+//to add a new collision behaviour, make a method that checks if it's the specific collision you want
+//you can distinguish bodies by their user data or make them collide with certain objects only with collision layers
+//if you need to use a component you have to do collider->setUserData(this) in the component's init first
+bool CollisionHandler::ObjectCollidesWithPlayer(b2Fixture* fixA, Health*& player)
+{	
+	if (player = static_cast<Health*>(fixA->GetBody()->GetUserData())) return true;
+	else return false;
 }
+
+//add pickable object method and grabbable object method here

--- a/src/SourceFiles/CollisionHandler.cpp
+++ b/src/SourceFiles/CollisionHandler.cpp
@@ -1,0 +1,30 @@
+#include "CollisionHandler.h"
+
+void CollisionHandler::BeginContact(b2Contact* contact)
+{ 
+	b2Fixture* fixA = contact->GetFixtureA();
+	b2Fixture* fixB = contact->GetFixtureB();
+
+	std::cout << "jajasi\n";
+
+	TriggerCollision(fixA, fixB);
+}
+
+void CollisionHandler::EndContact(b2Contact* contact)
+{ /* handle end event */
+}
+
+void CollisionHandler::PreSolve(b2Contact* contact, const b2Manifold* oldManifold)
+{ /* handle pre-solve event */
+}
+
+void CollisionHandler::PostSolve(b2Contact* contact, const b2ContactImpulse* impulse)
+{ /* handle post-solve event */
+}
+
+bool CollisionHandler::TriggerCollision(b2Fixture* fixA, b2Fixture* fixB) {
+	bool a = (fixA->IsSensor() || fixB->IsSensor());
+	if(a) std::cout << "trigger\n";
+	return a;
+	
+}

--- a/src/SourceFiles/CollisionHandler.h
+++ b/src/SourceFiles/CollisionHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <box2d.h>
 #include <iostream>
+#include "Health.h"
 
 class CollisionHandler :
 	public b2ContactListener
@@ -18,6 +19,6 @@ public:
 
     void PostSolve(b2Contact* contact, const b2ContactImpulse* impulse);
 
-    bool TriggerCollision(b2Fixture* fixA, b2Fixture* fixB);
+    bool ObjectCollidesWithPlayer(b2Fixture* fixA, Health*& player);
 };
 

--- a/src/SourceFiles/CollisionHandler.h
+++ b/src/SourceFiles/CollisionHandler.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <box2d.h>
+#include <iostream>
+
+class CollisionHandler :
+	public b2ContactListener
+{
+public:
+
+    CollisionHandler() {};
+    ~CollisionHandler() {};
+
+    void BeginContact(b2Contact* contact);
+
+    void EndContact(b2Contact* contact);
+
+    void PreSolve(b2Contact* contact, const b2Manifold* oldManifold);
+
+    void PostSolve(b2Contact* contact, const b2ContactImpulse* impulse);
+
+    bool TriggerCollision(b2Fixture* fixA, b2Fixture* fixB);
+};
+

--- a/src/SourceFiles/Constants.h
+++ b/src/SourceFiles/Constants.h
@@ -11,6 +11,7 @@ const int WINDOW_HEIGHT = 720;
 const int WINDOW_WIDTH = 1280;
 const std::string WINDOW_NAME = "PCE";
 const double MS_PER_FRAME = 1000.0/60.0; //Asumiendo 60fps
+const double SECONDS_PER_FRAME = 1.0 / 60.0;
 
 //Modos de juegos
 enum States

--- a/src/SourceFiles/Health.cpp
+++ b/src/SourceFiles/Health.cpp
@@ -1,9 +1,16 @@
 #include "Health.h"
 #include <iostream>
+#include "Collider.h"
+
 
 Health::Health(int l) : Component(ComponentType::Health)
 {
 	lives_ = livesMax_ = l;
+}
+
+void Health::init() {
+	col_ = GETCMP1_(Collider);
+	col_->setUserData(this);
 }
 
 Health::~Health()
@@ -13,7 +20,6 @@ Health::~Health()
 bool Health::subtractLife(int damage)
 {
 	lives_ -= damage;
-
 	if (lives_ > 0) return true;
 	else return false;
 }

--- a/src/SourceFiles/Health.h
+++ b/src/SourceFiles/Health.h
@@ -6,6 +6,10 @@
 
 class Health: public Component
 {
+private:
+	int lives_;
+	int livesMax_;
+	Collider* col_ = nullptr;
 public:
 	Health(int l);
 	~Health();
@@ -17,9 +21,6 @@ public:
 	void addLife(int sum); //suma sum a la vida siempre y cuando esta no supere la constanteGeneral
 	int getHealthMax() { return livesMax_; }
 	int getHealth() { return lives_; }
-private:
-	int lives_;
-	int livesMax_;
-	Collider* col_ = nullptr;
+
 };
 

--- a/src/SourceFiles/Health.h
+++ b/src/SourceFiles/Health.h
@@ -1,7 +1,8 @@
 #pragma once
 #include "Component.h"
 #include "checkML.h"
-
+#include "Collider.h"
+#include "Entity.h"
 
 class Health: public Component
 {
@@ -9,6 +10,8 @@ public:
 	Health(int l);
 	~Health();
 
+	virtual void init() override;
+	virtual void update() override {}
 	void resetHealth() { lives_ = livesMax_; }
 	bool subtractLife(int damage); //return true si despues del daño sigue vivo
 	void addLife(int sum); //suma sum a la vida siempre y cuando esta no supere la constanteGeneral
@@ -17,5 +20,6 @@ public:
 private:
 	int lives_;
 	int livesMax_;
+	Collider* col_ = nullptr;
 };
 

--- a/src/SourceFiles/PCE_Project.vcxproj
+++ b/src/SourceFiles/PCE_Project.vcxproj
@@ -173,6 +173,7 @@ copy "$(SolutionDir)SDL2_image-2.0.5\lib\$(Platform)\*.dll" "$(TargetDir)"</Comm
   <ItemGroup>
     <ClInclude Include="checkML.h" />
     <ClInclude Include="Collider.h" />
+    <ClInclude Include="CollisionHandler.h" />
     <ClInclude Include="Component.h" />
     <ClInclude Include="ComponentType.h" />
     <ClInclude Include="Constants.h" />
@@ -202,6 +203,7 @@ copy "$(SolutionDir)SDL2_image-2.0.5\lib\$(Platform)\*.dll" "$(TargetDir)"</Comm
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Collider.cpp" />
+    <ClCompile Include="CollisionHandler.cpp" />
     <ClCompile Include="Component.cpp" />
     <ClCompile Include="Entity.cpp" />
     <ClCompile Include="EntityManager.cpp" />

--- a/src/SourceFiles/PCE_Project.vcxproj.filters
+++ b/src/SourceFiles/PCE_Project.vcxproj.filters
@@ -99,6 +99,9 @@
     <ClInclude Include="HealthViewer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="CollisionHandler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="PCE_Project.cpp">
@@ -162,6 +165,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="InputHandler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CollisionHandler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/SourceFiles/PlayState.cpp
+++ b/src/SourceFiles/PlayState.cpp
@@ -24,16 +24,18 @@ void PlayState::init() {
 	CollisionHandler* col = new CollisionHandler();
 	physicsWorld_->SetContactListener(col);
 
-	Collider* collTinky = tinky->addComponent<Collider>(physicsWorld_, b2_dynamicBody, 150, 80, 50, 50, 50, 0, 0, 0, false);
-	Collider* collSuelo = ground->addComponent<Collider>(physicsWorld_, b2_staticBody, 0, 500, 1000, 10, 50, 0, 0, 0, false);
-	Collider* collRock = rock->addComponent<Collider>(physicsWorld_, b2_dynamicBody, 500, 80, 20, 20, 10, 0, 0, 0, false);
-	collTinky->createFixture(150, 80, 50, 50, 50, 0, true);
+	Collider* collTinky = tinky->addComponent<Collider>(physicsWorld_, b2_dynamicBody, 150, 80, 50, 50, 50, 0, 0,
+		Collider::CollisionLayer::Normal, false);
+	Collider* collSuelo = ground->addComponent<Collider>(physicsWorld_, b2_staticBody, 0, 500, 1000, 10, 50, 0, 0, 
+		Collider::CollisionLayer::Normal, false);
+	Collider* collRock = rock->addComponent<Collider>(physicsWorld_, b2_dynamicBody, 500, 80, 20, 20, 10, 0, 0, 
+		Collider::CollisionLayer::Triggers, false);
 	tinky->addComponent<Viewer>(Resources::Tinky);		//  <-- se puede poner un sprite con esta constructora, pero por defecto sale un tinky.
 	tinky->addComponent<Health>(3);
 	tinky->addComponent<HealthViewer>(Resources::ActiveHealth, Resources::DisableHealth, b2Vec2(20, 20));
 	ground->addComponent<Viewer>();
+	ground->addComponent<Health>(10);
 	rock->addComponent < Viewer >();
-	collRock->createFixture(100, 100, 10, 0, 0, 0, true);
 }
 
 void PlayState::update() {

--- a/src/SourceFiles/PlayState.cpp
+++ b/src/SourceFiles/PlayState.cpp
@@ -16,20 +16,21 @@ void PlayState::init() {
 	//aqui se crean todas las entidades necesarias
 	//se podría JSONizar para evitar compilar
 	entityManager_ = new EntityManager();
+
 	physicsWorld_ = new b2World(b2Vec2(0, 9.8));
+	collisionHandler_ = new CollisionHandler();
+	physicsWorld_->SetContactListener(collisionHandler_);
 	
 	Entity* tinky = entityManager_->addEntity();
 	Entity* ground = entityManager_->addEntity();
 	Entity* rock = entityManager_->addEntity();
-	CollisionHandler* col = new CollisionHandler();
-	physicsWorld_->SetContactListener(col);
-
+	
 	Collider* collTinky = tinky->addComponent<Collider>(physicsWorld_, b2_dynamicBody, 150, 80, 50, 50, 50, 0, 0,
 		Collider::CollisionLayer::Normal, false);
 	Collider* collSuelo = ground->addComponent<Collider>(physicsWorld_, b2_staticBody, 0, 500, 1000, 10, 50, 0, 0, 
 		Collider::CollisionLayer::Normal, false);
 	Collider* collRock = rock->addComponent<Collider>(physicsWorld_, b2_dynamicBody, 500, 80, 20, 20, 10, 0, 0, 
-		Collider::CollisionLayer::Triggers, false);
+		Collider::CollisionLayer::Trigger, false);
 	tinky->addComponent<Viewer>(Resources::Tinky);		//  <-- se puede poner un sprite con esta constructora, pero por defecto sale un tinky.
 	tinky->addComponent<Health>(3);
 	tinky->addComponent<HealthViewer>(Resources::ActiveHealth, Resources::DisableHealth, b2Vec2(20, 20));
@@ -40,7 +41,8 @@ void PlayState::init() {
 
 void PlayState::update() {
 	entityManager_->update();
-	physicsWorld_->Step(1.0f / 1.0f, 6, 2);
+	//el que vuelva tocar el step de physicsworld muere
+	physicsWorld_->Step(SECONDS_PER_FRAME, 6, 2);
 	//también debería actualizar la lógica de modo de juego
 	//spawners de monedas, carga de objetivos...
 	

--- a/src/SourceFiles/PlayState.cpp
+++ b/src/SourceFiles/PlayState.cpp
@@ -4,6 +4,7 @@
 #include "Health.h"
 #include "HealthViewer.h"
 #include "InputHandler.h"
+#include "CollisionHandler.h"
 
 PlayState::PlayState()  {
 }
@@ -20,10 +21,13 @@ void PlayState::init() {
 	Entity* tinky = entityManager_->addEntity();
 	Entity* ground = entityManager_->addEntity();
 	Entity* rock = entityManager_->addEntity();
+	CollisionHandler* col = new CollisionHandler();
+	physicsWorld_->SetContactListener(col);
 
 	Collider* collTinky = tinky->addComponent<Collider>(physicsWorld_, b2_dynamicBody, 150, 80, 50, 50, 50, 0, 0, 0, false);
 	Collider* collSuelo = ground->addComponent<Collider>(physicsWorld_, b2_staticBody, 0, 500, 1000, 10, 50, 0, 0, 0, false);
 	Collider* collRock = rock->addComponent<Collider>(physicsWorld_, b2_dynamicBody, 500, 80, 20, 20, 10, 0, 0, 0, false);
+	collTinky->createFixture(150, 80, 50, 50, 50, 0, true);
 	tinky->addComponent<Viewer>(Resources::Tinky);		//  <-- se puede poner un sprite con esta constructora, pero por defecto sale un tinky.
 	tinky->addComponent<Health>(3);
 	tinky->addComponent<HealthViewer>(Resources::ActiveHealth, Resources::DisableHealth, b2Vec2(20, 20));
@@ -34,7 +38,7 @@ void PlayState::init() {
 
 void PlayState::update() {
 	entityManager_->update();
-	physicsWorld_->Step(1.0f / 240.0f, 6, 2);
+	physicsWorld_->Step(1.0f / 1.0f, 6, 2);
 	//también debería actualizar la lógica de modo de juego
 	//spawners de monedas, carga de objetivos...
 	
@@ -50,7 +54,5 @@ void PlayState::handleInput() {
 	GameState::handleInput();
 	entityManager_->handleInput();
 	//DebugInput();
-
-
 }
 

--- a/src/SourceFiles/PlayState.h
+++ b/src/SourceFiles/PlayState.h
@@ -3,6 +3,7 @@
 #include "GameState.h"
 #include "Entity.h"
 #include "checkML.h"
+#include "collisionHandler.h"
 
 
 using namespace std;
@@ -13,6 +14,15 @@ using namespace std;
 class PlayState : public GameState
 {
 private:
+	EntityManager* entityManager_;
+	b2World* physicsWorld_;
+	vector<b2Body*> physicalEntities_; //almacena los punteros a los colliders de b2
+	//puede que no sea necesario si cogemos la referencia en cuanto los creamos con addPhysicalEntity
+	b2Body* addPhysicalEntity(/*PAR�METROS PARA PODER CREAR UN BODY*/) {};  //a�ade una entidad fisica
+	//HUD
+
+	CollisionHandler* collisionHandler_;
+
 public:
 	PlayState();
 	~PlayState();
@@ -20,14 +30,6 @@ public:
 	virtual void update();
 	virtual void render();
 	virtual void handleInput();
-private:
-	EntityManager* entityManager_;
-	b2World* physicsWorld_;
-	vector<b2Body*> physicalEntities_; //almacena los punteros a los colliders de b2
-	//puede que no sea necesario si cogemos la referencia en cuanto los creamos con addPhysicalEntity
-	b2Body* addPhysicalEntity(/*PAR�METROS PARA PODER CREAR UN BODY*/);  //a�ade una entidad fisica
-	//HUD
-	void DebugInput();
 
 };
 


### PR DESCRIPTION
[Finishes #171234302]
Colisión entre jugadores y otros objetos (para dañar al jugador) implementada de manera provisional como ejemplo de manejo de colisiones. Pick ups y grab se añadirán en el handler cuando estén.
También añadidos collision layers de verdad que funcionan por enum.