### PR TITLE
En el modo por tiempo, suicidarse ya no te da puntos

### DIFF
--- a/src/SourceFiles/Health.cpp
+++ b/src/SourceFiles/Health.cpp
@@ -106,12 +106,17 @@ void Health::onCollisionEnter(Collision* c)
 
 		if (!subtractLife(impact)) {
 			// player is killed by a weapon
-			if (objThrown != nullptr) objThrown->addPointsToOwner();
+			if (objThrown != nullptr) {
+				if(objThrown->getOwnerId() != GETCMP1_(PlayerData)->getPlayerNumber())
+					objThrown->addPointsToOwner();
+			}
 
 			// player is killed by another player at high speed
 			else if (playerWhoHitMe != nullptr) {
-				GameMode* s = c->collisionHandler->getGamemode();
-				s->playerKillsPlayer(playerWhoHitMe->getPlayerNumber());
+				if (playerWhoHitMe->getPlayerNumber() != GETCMP1_(PlayerData)->getPlayerNumber()) {
+					GameMode* s = c->collisionHandler->getGamemode();
+					s->playerKillsPlayer(playerWhoHitMe->getPlayerNumber());
+				}
 			}
 
 			playerDead(c);


### PR DESCRIPTION
Lanzar un objeto contra una pared y que te matara el rebote daba puntos, ya no