### PR TITLE
172411016 tile map jardin

### DIFF
--- a/assets/game/tilemaps/BoilerRoom.json
+++ b/assets/game/tilemaps/BoilerRoom.json
@@ -1,4 +1,12 @@
-{ "height":135,
+{ "compressionlevel":-1,
+ "editorsettings":
+    {
+     "export":
+        {
+         "target":"."
+        }
+    },
+ "height":135,
  "infinite":false,
  "layers":[
         {
@@ -52,7 +60,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }, 
@@ -235,7 +243,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }, 
@@ -258,68 +266,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
-         "x":0,
-         "y":0
-        }, 
-        {
-         "draworder":"topdown",
-         "id":5,
-         "name":"Spawns",
-         "objects":[
-                {
-                 "height":0,
-                 "id":6,
-                 "name":"Spawn",
-                 "point":true,
-                 "rotation":0,
-                 "type":"",
-                 "visible":true,
-                 "width":0,
-                 "x":1644,
-                 "y":291
-                }, 
-                {
-                 "height":0,
-                 "id":7,
-                 "name":"Spawn",
-                 "point":true,
-                 "rotation":0,
-                 "type":"",
-                 "visible":true,
-                 "width":0,
-                 "x":359,
-                 "y":248
-                }, 
-                {
-                 "height":0,
-                 "id":8,
-                 "name":"Spawn",
-                 "point":true,
-                 "rotation":0,
-                 "type":"",
-                 "visible":true,
-                 "width":0,
-                 "x":1589,
-                 "y":806
-                }, 
-                {
-                 "height":0,
-                 "id":9,
-                 "name":"Spawn",
-                 "point":true,
-                 "rotation":0,
-                 "type":"",
-                 "visible":true,
-                 "width":0,
-                 "x":308,
-                 "y":819
-                }],
-         "offsetx":2,
-         "offsety":-2,
-         "opacity":1,
-         "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }, 
@@ -390,6 +337,67 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
+         "visible":false,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "draworder":"topdown",
+         "id":5,
+         "name":"Spawns",
+         "objects":[
+                {
+                 "height":0,
+                 "id":6,
+                 "name":"P2",
+                 "point":true,
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":1644,
+                 "y":291
+                }, 
+                {
+                 "height":0,
+                 "id":7,
+                 "name":"P1",
+                 "point":true,
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":359,
+                 "y":248
+                }, 
+                {
+                 "height":0,
+                 "id":8,
+                 "name":"P4",
+                 "point":true,
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":1589,
+                 "y":806
+                }, 
+                {
+                 "height":0,
+                 "id":9,
+                 "name":"P3",
+                 "point":true,
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":308,
+                 "y":819
+                }],
+         "offsetx":2,
+         "offsety":-2,
+         "opacity":1,
+         "type":"objectgroup",
          "visible":true,
          "x":0,
          "y":0
@@ -449,7 +457,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }],
@@ -457,7 +465,7 @@
  "nextobjectid":83,
  "orientation":"orthogonal",
  "renderorder":"right-down",
- "tiledversion":"1.2.5",
+ "tiledversion":"1.3.3",
  "tileheight":8,
  "tilesets":[],
  "tilewidth":8,

--- a/assets/game/tilemaps/GardenRoom.json
+++ b/assets/game/tilemaps/GardenRoom.json
@@ -60,7 +60,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }, 
@@ -118,7 +118,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }, 
@@ -141,7 +141,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }, 
@@ -153,7 +153,7 @@
                 {
                  "height":0,
                  "id":6,
-                 "name":"Spawn",
+                 "name":"P2",
                  "point":true,
                  "rotation":0,
                  "type":"",
@@ -165,7 +165,7 @@
                 {
                  "height":0,
                  "id":7,
-                 "name":"Spawn",
+                 "name":"P1",
                  "point":true,
                  "rotation":0,
                  "type":"",
@@ -177,7 +177,7 @@
                 {
                  "height":0,
                  "id":8,
-                 "name":"Spawn",
+                 "name":"P4",
                  "point":true,
                  "rotation":0,
                  "type":"",
@@ -189,7 +189,7 @@
                 {
                  "height":0,
                  "id":9,
-                 "name":"Spawn",
+                 "name":"P3",
                  "point":true,
                  "rotation":0,
                  "type":"",
@@ -273,7 +273,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }, 
@@ -332,7 +332,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }],

--- a/assets/game/tilemaps/GardenRoom.json
+++ b/assets/game/tilemaps/GardenRoom.json
@@ -106,15 +106,15 @@
                  "y":472
                 }, 
                 {
-                 "height":410,
-                 "id":86,
-                 "name":"Pad",
+                 "height":200,
+                 "id":87,
+                 "name":"CarnivorousePlant",
                  "rotation":0,
                  "type":"",
                  "visible":true,
-                 "width":84,
-                 "x":86,
-                 "y":338
+                 "width":200,
+                 "x":80,
+                 "y":416
                 }],
          "opacity":1,
          "type":"objectgroup",

--- a/assets/game/tilemaps/GardenRoom.json
+++ b/assets/game/tilemaps/GardenRoom.json
@@ -60,7 +60,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":false,
+         "visible":true,
          "x":0,
          "y":0
         }, 
@@ -94,18 +94,6 @@
                  "y":154
                 }, 
                 {
-                 "height":0,
-                 "id":83,
-                 "name":"Treadmill",
-                 "point":true,
-                 "rotation":0,
-                 "type":"",
-                 "visible":true,
-                 "width":0,
-                 "x":802,
-                 "y":472
-                }, 
-                {
                  "height":200,
                  "id":87,
                  "name":"CarnivorousePlant",
@@ -118,7 +106,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":false,
+         "visible":true,
          "x":0,
          "y":0
         }, 
@@ -141,7 +129,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":false,
+         "visible":true,
          "x":0,
          "y":0
         }, 
@@ -273,7 +261,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":false,
+         "visible":true,
          "x":0,
          "y":0
         }, 
@@ -332,7 +320,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":false,
+         "visible":true,
          "x":0,
          "y":0
         }],

--- a/assets/game/tilemaps/GymRoom.json
+++ b/assets/game/tilemaps/GymRoom.json
@@ -60,7 +60,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }, 
@@ -118,7 +118,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }, 
@@ -141,7 +141,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }, 
@@ -153,7 +153,7 @@
                 {
                  "height":0,
                  "id":6,
-                 "name":"Spawn",
+                 "name":"P2",
                  "point":true,
                  "rotation":0,
                  "type":"",
@@ -165,7 +165,7 @@
                 {
                  "height":0,
                  "id":7,
-                 "name":"Spawn",
+                 "name":"P1",
                  "point":true,
                  "rotation":0,
                  "type":"",
@@ -177,7 +177,7 @@
                 {
                  "height":0,
                  "id":8,
-                 "name":"Spawn",
+                 "name":"P4",
                  "point":true,
                  "rotation":0,
                  "type":"",
@@ -189,7 +189,7 @@
                 {
                  "height":0,
                  "id":9,
-                 "name":"Spawn",
+                 "name":"P3",
                  "point":true,
                  "rotation":0,
                  "type":"",
@@ -273,7 +273,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }, 
@@ -332,7 +332,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }],

--- a/assets/game/tilemaps/LivingRoom.json
+++ b/assets/game/tilemaps/LivingRoom.json
@@ -25,7 +25,7 @@
                  "width":1920,
                  "x":0,
                  "y":0
-                },
+                }, 
                 {
                  "height":30,
                  "id":3,
@@ -36,7 +36,7 @@
                  "width":1920,
                  "x":0,
                  "y":1050
-                },
+                }, 
                 {
                  "height":1080,
                  "id":4,
@@ -47,7 +47,7 @@
                  "width":30,
                  "x":0,
                  "y":0
-                },
+                }, 
                 {
                  "height":1080,
                  "id":5,
@@ -61,10 +61,10 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
-        },
+        }, 
         {
          "draworder":"topdown",
          "id":3,
@@ -81,7 +81,7 @@
                  "width":0,
                  "x":554,
                  "y":528
-                },
+                }, 
                 {
                  "height":0,
                  "id":27,
@@ -96,10 +96,10 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
-        },
+        }, 
         {
          "draworder":"topdown",
          "id":4,
@@ -119,10 +119,10 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
-        },
+        }, 
         {
          "draworder":"topdown",
          "id":5,
@@ -131,57 +131,57 @@
                 {
                  "height":0,
                  "id":6,
-                 "name":"Spawn",
+                 "name":"P2",
                  "point":true,
                  "rotation":0,
                  "type":"",
                  "visible":true,
                  "width":0,
-                 "x":960,
-                 "y":75
-                },
+                 "x":1756,
+                 "y":175
+                }, 
                 {
                  "height":0,
                  "id":7,
-                 "name":"Spawn",
+                 "name":"P1",
                  "point":true,
                  "rotation":0,
                  "type":"",
                  "visible":true,
                  "width":0,
-                 "x":75,
-                 "y":540
-                },
+                 "x":217,
+                 "y":238
+                }, 
                 {
                  "height":0,
                  "id":8,
-                 "name":"Spawn",
+                 "name":"P4",
                  "point":true,
                  "rotation":0,
                  "type":"",
                  "visible":true,
                  "width":0,
-                 "x":1845,
-                 "y":540
-                },
+                 "x":1719,
+                 "y":882
+                }, 
                 {
                  "height":0,
                  "id":9,
-                 "name":"Spawn",
+                 "name":"P3",
                  "point":true,
                  "rotation":0,
                  "type":"",
                  "visible":true,
                  "width":0,
-                 "x":960,
-                 "y":1005
+                 "x":316,
+                 "y":917
                 }],
          "opacity":1,
          "type":"objectgroup",
          "visible":true,
          "x":0,
          "y":0
-        },
+        }, 
         {
          "draworder":"topdown",
          "id":7,
@@ -198,7 +198,7 @@
                  "width":0,
                  "x":488,
                  "y":272
-                },
+                }, 
                 {
                  "height":0,
                  "id":21,
@@ -210,7 +210,7 @@
                  "width":0,
                  "x":1146,
                  "y":236
-                },
+                }, 
                 {
                  "height":0,
                  "id":22,
@@ -222,7 +222,7 @@
                  "width":0,
                  "x":1478,
                  "y":380
-                },
+                }, 
                 {
                  "height":0,
                  "id":23,
@@ -234,7 +234,7 @@
                  "width":0,
                  "x":1404,
                  "y":922
-                },
+                }, 
                 {
                  "height":0,
                  "id":24,
@@ -249,10 +249,10 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
-        },
+        }, 
         {
          "draworder":"topdown",
          "id":6,
@@ -269,7 +269,7 @@
                  "width":0,
                  "x":960,
                  "y":300
-                },
+                }, 
                 {
                  "height":0,
                  "id":11,
@@ -281,7 +281,7 @@
                  "width":0,
                  "x":540,
                  "y":540
-                },
+                }, 
                 {
                  "height":0,
                  "id":12,
@@ -293,7 +293,7 @@
                  "width":0,
                  "x":960,
                  "y":780
-                },
+                }, 
                 {
                  "height":0,
                  "id":13,
@@ -308,7 +308,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }],

--- a/assets/game/tilemaps/TutorialRoom.json
+++ b/assets/game/tilemaps/TutorialRoom.json
@@ -25,7 +25,7 @@
                  "width":1920,
                  "x":0,
                  "y":0
-                },
+                }, 
                 {
                  "height":30,
                  "id":3,
@@ -36,7 +36,7 @@
                  "width":1920,
                  "x":0,
                  "y":1050
-                },
+                }, 
                 {
                  "height":1080,
                  "id":4,
@@ -47,7 +47,7 @@
                  "width":30,
                  "x":0,
                  "y":0
-                },
+                }, 
                 {
                  "height":1080,
                  "id":5,
@@ -64,7 +64,7 @@
          "visible":true,
          "x":0,
          "y":0
-        },
+        }, 
         {
          "draworder":"topdown",
          "id":5,
@@ -73,50 +73,50 @@
                 {
                  "height":0,
                  "id":6,
-                 "name":"Spawn",
+                 "name":"P1",
                  "point":true,
                  "rotation":0,
                  "type":"",
                  "visible":true,
                  "width":0,
-                 "x":960,
-                 "y":75
-                },
+                 "x":85.5984652598214,
+                 "y":87.8117440987572
+                }, 
                 {
                  "height":0,
                  "id":7,
-                 "name":"Spawn",
+                 "name":"P3",
                  "point":true,
                  "rotation":0,
                  "type":"",
                  "visible":true,
                  "width":0,
-                 "x":75,
-                 "y":540
-                },
+                 "x":91.0146801234465,
+                 "y":994.81691550588
+                }, 
                 {
                  "height":0,
                  "id":8,
-                 "name":"Spawn",
+                 "name":"P2",
                  "point":true,
                  "rotation":0,
                  "type":"",
                  "visible":true,
                  "width":0,
-                 "x":1845,
-                 "y":540
-                },
+                 "x":1841.79706397531,
+                 "y":115.610976728668
+                }, 
                 {
                  "height":0,
                  "id":9,
-                 "name":"Spawn",
+                 "name":"P4",
                  "point":true,
                  "rotation":0,
                  "type":"",
                  "visible":true,
                  "width":0,
-                 "x":960,
-                 "y":1005
+                 "x":1816.78538660439,
+                 "y":1003.39853198766
                 }],
          "opacity":1,
          "type":"objectgroup",

--- a/src/SourceFiles/MenuState.h
+++ b/src/SourceFiles/MenuState.h
@@ -25,7 +25,8 @@ private:
 	std::map<int, string> maps_ = { //añadir aquí los mapas que se vayan haciendo, tutorial no
 		{ 0, "LivingRoom"},
 		{ 1, "BoilerRoom"},
-		{ 2, "GymRoom"}
+		{ 2, "GymRoom"},
+		{ 3, "GardenRoom"}
 	};
 
 	void updatePointer(int n);

--- a/src/SourceFiles/Resources.cpp
+++ b/src/SourceFiles/Resources.cpp
@@ -117,6 +117,7 @@ vector<Resources::TextMsgInfo> Resources::messages_{
 	{ LivingRoomText, "Living Room", { COLOR(0xc7f2edff) }, FontId::NES_Chimera },
 	{ BoilerRoomText, "Boiler Room", { COLOR(0xc7f2edff) }, FontId::NES_Chimera },
 	{ GymRoomText, "Gym Room", { COLOR(0xc7f2edff) }, FontId::NES_Chimera },
+	{ GardenRoomText, "Garden Room", { COLOR(0xc7f2edff) }, FontId::NES_Chimera },
 	//players
 	{ OnePlayer, "1 Player", { COLOR(0xc7f2edff) }, FontId::NES_Chimera },
 	{ TwoPlayers, "2 Players", { COLOR(0xc7f2edff) }, FontId::NES_Chimera },

--- a/src/SourceFiles/Resources.h
+++ b/src/SourceFiles/Resources.h
@@ -120,6 +120,7 @@ public:
 		LivingRoomText,
 		BoilerRoomText,
 		GymRoomText,
+		GardenRoomText,
 
 		//players
 		OnePlayer,
@@ -135,7 +136,7 @@ public:
 		One,
 		Two,
 		Three,
-		Four,	
+		Four,
 		MoveTutorial,
 		HoldTutorial,
 		GrabTutorial,

--- a/src/SourceFiles/TileMap.cpp
+++ b/src/SourceFiles/TileMap.cpp
@@ -11,8 +11,12 @@ TileMap::TileMap(int w, int h, string map, EntityManager* eM, b2World* pW) :Comp
 width_(w),
 height_(h),
 entityManager_(eM),
-physicsWorld_(pW){
+physicsWorld_(pW) {
 	loadTileson(map);
+	playerSpawns_.reserve(4);
+	for (int i = 0; i < 4; i++) { //inicializa el vector
+		playerSpawns_.push_back(b2Vec2());
+	}
 }
 
 TileMap::~TileMap() {
@@ -34,9 +38,12 @@ void TileMap::init() {
 					factoryItems_.push_back(obj);
 				}
 				else if (tileLayer.getName() == "Spawns") { //spawns
-					playerSpawns_.push_back(b2Vec2(obj.getPosition().x / CONST(double, "PIXELS_PER_METER"), (CONST(int, "WINDOW_HEIGHT") - obj.getPosition().y) / CONST(double, "PIXELS_PER_METER"))); //a�ade la posicion al vector de spawns
+					if (obj.getName() == "P1") playerSpawns_[0] = b2Vec2(obj.getPosition().x / CONST(double, "PIXELS_PER_METER"), (CONST(int, "WINDOW_HEIGHT") - obj.getPosition().y) / CONST(double, "PIXELS_PER_METER"));
+					else if (obj.getName() == "P2")playerSpawns_[1] = b2Vec2(obj.getPosition().x / CONST(double, "PIXELS_PER_METER"), (CONST(int, "WINDOW_HEIGHT") - obj.getPosition().y) / CONST(double, "PIXELS_PER_METER"));
+					else if (obj.getName() == "P3")playerSpawns_[2] = b2Vec2(obj.getPosition().x / CONST(double, "PIXELS_PER_METER"), (CONST(int, "WINDOW_HEIGHT") - obj.getPosition().y) / CONST(double, "PIXELS_PER_METER"));
+					else if (obj.getName() == "P4")playerSpawns_[3] = b2Vec2(obj.getPosition().x / CONST(double, "PIXELS_PER_METER"), (CONST(int, "WINDOW_HEIGHT") - obj.getPosition().y) / CONST(double, "PIXELS_PER_METER"));
 				}
-				else if (tileLayer.getName() == "SpecialObjects"){ //objetos espaciales (mando de tele, router...)
+				else if (tileLayer.getName() == "SpecialObjects") { //objetos espaciales (mando de tele, router...)
 					specialObjectsSpawnPoint_ = b2Vec2(obj.getPosition().x / CONST(double, "PIXELS_PER_METER"), (CONST(int, "WINDOW_HEIGHT") - obj.getPosition().y) / CONST(double, "PIXELS_PER_METER"));
 				}
 				else if (tileLayer.getName() == "MapObjects") { //muebles
@@ -176,18 +183,18 @@ void TileMap::executeMapFactory()
 		}
 		else if (name == "DecButton") {
 			boilerButtons_.push_back(GETCMP2(ObjectFactory::makeBoilerButton(entityManager_, physicsWorld_, pos, false), BoilerButtonLogic));
-		}		
+		}
 		else if (name == "Pipe") {
 			float rotation = o.getRotation();
 			size = b2Vec2(s.x / CONST(double, "PIXELS_PER_METER"), s.y / CONST(double, "PIXELS_PER_METER"));
 			pos = b2Vec2(pos.x + (size.x / 2), pos.y - (size.y / 2));
 			size *= 0.5f;
 
-			ObjectFactory::makePipe(entityManager_, physicsWorld_, pos, size, rotation); 
+			ObjectFactory::makePipe(entityManager_, physicsWorld_, pos, size, rotation);
 		}
 		else if (name == "Treadmill") {
 			ObjectFactory::makeTreadmill(entityManager_, physicsWorld_, pos);
-		}	
+		}
 		else if (name == "CarnivorousePlant") {
 			size = b2Vec2(s.x / CONST(double, "PIXELS_PER_METER"), (s.y) / CONST(double, "PIXELS_PER_METER"));
 			pos = b2Vec2(pos.x + (size.x / 2), pos.y - (size.y / 2));
@@ -222,7 +229,7 @@ void TileMap::createWeapons()
 		switch (weapon)
 		{
 		case 0: //slipper
-			e = ObjectFactory::makeSlipper(entityManager_,physicsWorld_, spawnPoint, b2Vec2(CONST(float, "SLIPPER_X"), CONST(float, "SLIPPER_Y")));
+			e = ObjectFactory::makeSlipper(entityManager_, physicsWorld_, spawnPoint, b2Vec2(CONST(float, "SLIPPER_X"), CONST(float, "SLIPPER_Y")));
 			break;
 		case 1: //ball
 			e = ObjectFactory::makeBall(entityManager_, physicsWorld_, spawnPoint, b2Vec2(CONST(float, "BALL_X"), CONST(float, "BALL_Y")));


### PR DESCRIPTION
Nueva opción en el menú para elegir mapa, nuevo json y un refactor

**Refactor**
Ahora en tiled los spawns no se llaman spawns, se llaman P1, P2... pero siguen estando en la capa Spawns. De esta manera se puede elegir la posición de spawn de cada jugador