### PR TITLE
He retocado lo del impulso cuando vas a velocidad máxima

### DIFF
--- a/src/SourceFiles/PlayerController.cpp
+++ b/src/SourceFiles/PlayerController.cpp
@@ -45,7 +45,10 @@ void PlayerController::handleInput()
 
 		// si se pasa del l�mite de velocidad le bajamos los humos (s�lo aplica cuando no est�s agarrao)
 		Vector2D velAfterImpulse = {(coll_->getLinearVelocity() + dirImpulse_).x, (coll_->getLinearVelocity() + dirImpulse_).y };
-		if (!attachesToObj_->isAttached() && velAfterImpulse.magnitude() > maxSpeedAfterImpulse_) dirImpulse_ = { 0, 0 };
+		if (!attachesToObj_->isAttached()) {
+			if(abs(velAfterImpulse.getX()) > maxSpeedAfterImpulse_) dirImpulse_.x = 0;
+			if(abs(velAfterImpulse.getY()) > maxSpeedAfterImpulse_) dirImpulse_.y = 0;
+		}
 
 		Collider* attachedObj = attachesToObj_->getAttachedObject();
 		if (attachedObj != nullptr) {


### PR DESCRIPTION
Ahora es más orgánico porque no te cancela las dos componentes del vector, sino que te permite impulsarte en otra dirección a una velocidad no mayor.
Antes te cancelaba por completo el movimiento y era un poco raro porque si ibas muy rápido no podías impulsarte en otra dirección.