### PR TITLE
BugFix reactivación al soltar un arma

### DIFF
--- a/src/SourceFiles/Weapon.cpp
+++ b/src/SourceFiles/Weapon.cpp
@@ -177,7 +177,8 @@ void Weapon::update() {
 		if (framesUntilRecoveringCollisionTimer_ >= framesUntilRecoveringCollision_) {
 			hasBeenThrownRecently_ = false;
 			framesUntilRecoveringCollisionTimer_ = 0;
-			mainCollider_->getFixture(0)->SetFilterData(mainCollider_->getFilterFromLayer(Collider::CollisionLayer::NormalObject));
+			if(currentHand_ == nullptr)
+				mainCollider_->getFixture(0)->SetFilterData(mainCollider_->getFilterFromLayer(Collider::CollisionLayer::NormalObject));
 		}
 	}
 }


### PR DESCRIPTION
La layer de colisión se reactivaba a pesar de que el objeto había sido cogido