### PR TITLE
BugFix: Si te chocas con un arma antes de cogerla, no la puedes coger

### DIFF
--- a/src/SourceFiles/Weapon.cpp
+++ b/src/SourceFiles/Weapon.cpp
@@ -136,7 +136,7 @@ void Weapon::onCollisionEnter(Collision* c)
 	Entity* other = c->entity;
 	Hands* otherHand = GETCMP2(other, Hands);
 	Collider* coll = GETCMP1_(Collider);
-	b2Fixture* auxF = coll->getFixture(1);
+	b2Fixture* auxF = c->myFixture ;
 
 	if (otherHand != nullptr &&
 		auxF->GetFilterData().categoryBits == Collider::CollisionLayer::Trigger) {
@@ -147,8 +147,10 @@ void Weapon::onCollisionEnter(Collision* c)
 void Weapon::onCollisionExit(Collision* c)
 {
 	Hands* otherHand = GETCMP2(c->entity, Hands);
+	b2Fixture* auxF = c->myFixture;
 
-	if (otherHand != nullptr) {
+	if (otherHand != nullptr &&
+		auxF->GetFilterData().categoryBits == Collider::CollisionLayer::Trigger) {
 		DeletePlayerInfo(otherHand->getPlayerId());
 	}
 }


### PR DESCRIPTION
Eliminado momento frustrante en el que tenias que volver a salir  y entrar en el trigger del arma porque a veces no la podias coger.